### PR TITLE
django 2,  use template views, specify default_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ While running the Django test server:
 
 Adding Your Own Service Worker
 =====
-By default, the service worker implemented by this app is empty.  To add service worker functionality, you'll want to create a `serviceworker.js` or similarly named file, and then point at it using the PWA_SERVICE_WORKER_PATH variable.
+By default, the service worker implemented by this app is empty.  To add service worker functionality, you'll want to create a `serviceworker.js` or similarly named template in a template directory, and then point at it using the PWA_SERVICE_WORKER_PATH variable (PWA_APP_FETCH_URL is passed through).
 
 ```python
-PWA_SERVICE_WORKER_PATH = os.path.join(BASE_DIR, 'my_app', 'serviceworker.js')
+PWA_SERVICE_WORKER_PATH = 'my_app/serviceworker.js'
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ All settings are optional, and the app will work fine with its internal defaults
 
 Add the progressive web app URLs to urls.py:
 ```python
-from django.conf.urls import url, include
+from django.urls import path, include
 
 urlpatterns = [
     ...
-    url('', include('pwa.urls')),  # You MUST use an empty string as the URL prefix
+    path('', include('pwa.urls')),  # You MUST use an empty string as the URL prefix
     ...
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ While running the Django test server:
 
 Adding Your Own Service Worker
 =====
-By default, the service worker implemented by this app is empty.  To add service worker functionality, you'll want to create a `serviceworker.js` or similarly named template in a template directory, and then point at it using the PWA_SERVICE_WORKER_PATH variable (PWA_APP_FETCH_URL is passed through).
+By default, the service worker implemented by this app is empty.  To add service worker functionality, you'll want to create a `serviceworker.js` or similarly named template in a template directory, and then point at it using the PWA_SERVICE_WORKER_PATH variable.
 
 ```python
 PWA_SERVICE_WORKER_PATH = 'my_app/serviceworker.js'

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ PWA_APP_ICONS = [
 
 All settings are optional, and the app will work fine with its internal defaults.  Highly recommend setting at least `PWA_APP_NAME` and `PWA_APP_DESCRIPTION`.
 
-Add the progressive web app URLs to urls.py:
+Add the progressive web app URLs to urls.py (django >= 2):
 ```python
 from django.urls import path, include
 
@@ -57,6 +57,18 @@ urlpatterns = [
     ...
 ]
 ```
+
+the old way (django < 2.0):
+```python
+from django.conf.urls import url, include
+
+urlpatterns = [
+    ...
+    url('', include('pwa.urls')),  # You MUST use an empty string as the URL prefix
+    ...
+]
+```
+
 
 Inject the required meta tags in your base.html (or wherever your HTML &lt;head&gt; is defined):
 ```html

--- a/pwa/__init__.py
+++ b/pwa/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'pwa.apps.PwaConfig'

--- a/pwa/app_settings.py
+++ b/pwa/app_settings.py
@@ -3,8 +3,7 @@ from django.conf import settings
 import os
 
 # Path to the service worker implementation.  Default implementation is empty.
-PWA_SERVICE_WORKER_PATH = getattr(settings, 'PWA_SERVICE_WORKER_PATH',
-                                  os.path.join(os.path.abspath(os.path.dirname(__file__)), 'templates', 'serviceworker.js'))
+PWA_SERVICE_WORKER_PATH = getattr(settings, 'PWA_SERVICE_WORKER_PATH', 'serviceworker.js')
 
 # App parameters to include in manifest.json and appropriate meta tags
 PWA_APP_NAME = getattr(settings, 'PWA_APP_NAME', 'MyApp')

--- a/pwa/app_settings.py
+++ b/pwa/app_settings.py
@@ -12,7 +12,6 @@ PWA_APP_ROOT_URL = getattr(settings, 'PWA_APP_ROOT_URL', '/')
 PWA_APP_THEME_COLOR = getattr(settings, 'PWA_APP_THEME_COLOR', '#000')
 PWA_APP_DISPLAY = getattr(settings, 'PWA_APP_DISPLAY', 'standalone')
 PWA_APP_START_URL = getattr(settings, 'PWA_APP_START_URL', '/')
-PWA_APP_FETCH_URL = getattr(settings, 'PWA_APP_FETCH_URL', '/')
 PWA_APP_ICONS = getattr(settings, 'PWA_APP_ICONS', [
     {
         'src': '/',

--- a/pwa/app_settings.py
+++ b/pwa/app_settings.py
@@ -19,5 +19,3 @@ PWA_APP_ICONS = getattr(settings, 'PWA_APP_ICONS', [
         'sizes': '160x160'
     }
 ])
-
-

--- a/pwa/app_settings.py
+++ b/pwa/app_settings.py
@@ -13,6 +13,7 @@ PWA_APP_ROOT_URL = getattr(settings, 'PWA_APP_ROOT_URL', '/')
 PWA_APP_THEME_COLOR = getattr(settings, 'PWA_APP_THEME_COLOR', '#000')
 PWA_APP_DISPLAY = getattr(settings, 'PWA_APP_DISPLAY', 'standalone')
 PWA_APP_START_URL = getattr(settings, 'PWA_APP_START_URL', '/')
+PWA_APP_FETCH_URL = getattr(settings, 'PWA_APP_FETCH_URL', '/')
 PWA_APP_ICONS = getattr(settings, 'PWA_APP_ICONS', [
     {
         'src': '/',

--- a/pwa/urls.py
+++ b/pwa/urls.py
@@ -1,8 +1,17 @@
-from django.urls import path
+import django
 from .views import Manifest, ServiceWorker
 
-# Serve up serviceworker.js and manifest.json at the root
-urlpatterns = [
-    path('serviceworker.js', ServiceWorker.as_view()),
-    path('manifest.json', Manifest.as_view())
-]
+if django.VERSION[0] >= 2:
+    from django.urls import path
+    # Serve up serviceworker.js and manifest.json at the root
+    urlpatterns = [
+        path('serviceworker.js', ServiceWorker.as_view()),
+        path('manifest.json', Manifest.as_view())
+    ]
+else:
+    from django.conf.urls import url
+    # Serve up serviceworker.js and manifest.json at the root
+    urlpatterns = [
+        url('serviceworker.js$', ServiceWorker.as_view()),
+        url('manifest.json$', Manifest.as_view())
+    ]

--- a/pwa/urls.py
+++ b/pwa/urls.py
@@ -1,8 +1,8 @@
 from django.urls import path
-from .views import manifest, service_worker
+from .views import Manifest, ServiceWorker
 
 # Serve up serviceworker.js and manifest.json at the root
 urlpatterns = [
-    path('serviceworker.js', service_worker),
-    path('manifest.json', manifest)
+    path('serviceworker.js', ServiceWorker.as_view()),
+    path('manifest.json', Manifest.as_view())
 ]

--- a/pwa/urls.py
+++ b/pwa/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import path
 from .views import manifest, service_worker
 
 # Serve up serviceworker.js and manifest.json at the root
 urlpatterns = [
-    url('^serviceworker.js$', service_worker),
-    url('^manifest.json$', manifest)
+    path('serviceworker.js', service_worker),
+    path('manifest.json', manifest)
 ]

--- a/pwa/views.py
+++ b/pwa/views.py
@@ -1,5 +1,5 @@
 from django.http import HttpResponse
-from django.views.generic.base import TemplateView
+from django.views.generic import TemplateView
 
 from . import app_settings
 

--- a/pwa/views.py
+++ b/pwa/views.py
@@ -7,6 +7,9 @@ from . import app_settings
 class ServiceWorker(TemplateView):
     content_type = 'application/javascript'
     template_name = app_settings.PWA_SERVICE_WORKER_PATH
+    def get_context_data(self, **kwargs):
+        kwargs['PWA_APP_FETCH_URL'] = app_settings.PWA_APP_FETCH_URL
+        return super().get_context_data(**kwargs)
 
 class Manifest(TemplateView):
     content_type = 'application/json'

--- a/pwa/views.py
+++ b/pwa/views.py
@@ -1,5 +1,4 @@
 from django.http import HttpResponse
-from django.shortcuts import render
 from django.views.generic.base import TemplateView
 
 from . import app_settings
@@ -7,6 +6,7 @@ from . import app_settings
 class ServiceWorker(TemplateView):
     content_type = 'application/javascript'
     template_name = app_settings.PWA_SERVICE_WORKER_PATH
+
     def get_context_data(self, **kwargs):
         kwargs['PWA_APP_FETCH_URL'] = app_settings.PWA_APP_FETCH_URL
         return super().get_context_data(**kwargs)

--- a/pwa/views.py
+++ b/pwa/views.py
@@ -7,10 +7,6 @@ class ServiceWorker(TemplateView):
     content_type = 'application/javascript'
     template_name = app_settings.PWA_SERVICE_WORKER_PATH
 
-    def get_context_data(self, **kwargs):
-        kwargs['PWA_APP_FETCH_URL'] = app_settings.PWA_APP_FETCH_URL
-        return super().get_context_data(**kwargs)
-
 class Manifest(TemplateView):
     content_type = 'application/json'
     template_name = 'manifest.json'

--- a/pwa/views.py
+++ b/pwa/views.py
@@ -1,17 +1,19 @@
 from django.http import HttpResponse
 from django.shortcuts import render
+from django.views.generic.base import TemplateView
 
 from . import app_settings
 
+class ServiceWorker(TemplateView):
+    content_type = 'application/javascript'
+    template_name = app_settings.PWA_SERVICE_WORKER_PATH
 
-def service_worker(request):
-    response = HttpResponse(open(app_settings.PWA_SERVICE_WORKER_PATH).read(), content_type='application/javascript')
-    return response
+class Manifest(TemplateView):
+    content_type = 'application/json'
+    template_name = 'manifest.json'
 
-
-def manifest(request):
-    return render(request, 'manifest.json', {
-        setting_name: getattr(app_settings, setting_name)
-        for setting_name in dir(app_settings)
-        if setting_name.startswith('PWA_')
-    })
+    def get_context_data(self, **kwargs):
+        for setting_name in dir(app_settings):
+            if setting_name.startswith('PWA_'):
+                kwargs[setting_name] = getattr(app_settings, setting_name)
+        return super().get_context_data(**kwargs)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except:
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 install_requirements = [
-    "django>=1.11,<3.0",
+    "django>=1.11",
 ]
 setup(
     name='django-progressive-web-app',

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,14 @@ except:
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
+install_requirements = [
+    "django>=2",
+]
 setup(
     name='django-progressive-web-app',
     version='0.1',
     packages=find_packages(),
+    install_requires=install_requirements,
     include_package_data=True,
     license='MIT License',
     description=short_description,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except:
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 install_requirements = [
-    "django>=2",
+    "django>=1.11,<3.0",
 ]
 setup(
     name='django-progressive-web-app',
@@ -34,6 +34,7 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
+        'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Hello,
I rewrote some of your code for django 2 support and cleaner solutions.
My changes are:
* add django 2 requirement and some fixes
* use templateviews instead of own implementations (can use context stuff now in serviceworker.js)
* add content_types 
* update README.md
* add PWA_APP_FETCH_URL (later for my own serviceworker.js default implementation)
* add default_config in \_\_init__.py (sometimes required for finding the apps config)
I can seperate the commit request if wished

