### PR TITLE
Enable rendering with custom serviceworker and update base serviceworker template to at least run.

### DIFF
--- a/pwa/templates/serviceworker.js
+++ b/pwa/templates/serviceworker.js
@@ -1,2 +1,3 @@
-// Empty Service Worker implementation.  To use your own Service Worker, set the PWA_SERVICE_WORKER_PATH variable in
+self.addEventListener('fetch', function(event) {});
+// Base Service Worker implementation.  To use your own Service Worker, set the PWA_SERVICE_WORKER_PATH variable in
 // settings.py

--- a/pwa/views.py
+++ b/pwa/views.py
@@ -1,11 +1,10 @@
-from django.http import HttpResponse
 from django.shortcuts import render
 
 from . import app_settings
 
 
 def service_worker(request):
-    response = HttpResponse(open(app_settings.PWA_SERVICE_WORKER_PATH).read(), content_type='application/javascript')
+    response = render(request, app_settings.PWA_SERVICE_WORKER_PATH, content_type='application/javascript')
     return response
 
 


### PR DESCRIPTION
serviceworker.js:
I noticed that an empty serviceworker file was giving an error "Site cannot be installed: the page does not work offline", so I updated the "empty" template to have code that allows it to initialize. Could be caused by recent updates to Chrome.

views.py:
As I was getting into more detailed serviceworker config, I noticed that it would help to be able to render static from within my custom serviceworker location, so I updated the endpoint to call a render on the source.